### PR TITLE
Replace Mix.Dep.loaded/1 (removed in Elixir 1.9) with Mix.Dep.load_on_environment/1

### DIFF
--- a/lib/mix/tasks/archive/build.deps.ex
+++ b/lib/mix/tasks/archive/build.deps.ex
@@ -69,7 +69,7 @@ defmodule Mix.Tasks.Archive.Build.Deps do
     skip = Helpers.skipped_apps(opts)
 
     ## Build delendencies archives
-    Mix.Dep.loaded(env: Mix.env)
+    Mix.Dep.load_on_environment([])
     |>  Enum.filter(fn(%Mix.Dep{app: app}) -> not Enum.member?(skip, app) end)
     |>  Enum.map(fn(%Mix.Dep{app: app, status: status}) ->
       version = case status do

--- a/mix.exs
+++ b/mix.exs
@@ -22,7 +22,7 @@ defmodule MixTaskArchiveDeps.Mixfile do
   def project do
     [app: :mix_task_archive_deps,
      version: "0.4.0",
-     elixir: "~> 1.4",
+     elixir: "~> 1.7",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      description: "Mix task to create archives for a project dependencies and elixir itself",


### PR DESCRIPTION
This is required to work with Elixir 1.9-dev. It increases the required Elixir version to 1.7.